### PR TITLE
Added destroy method to safely close the httpClient connections

### DIFF
--- a/src/main/java/com/rusticisoftware/tincan/LRS.java
+++ b/src/main/java/com/rusticisoftware/tincan/LRS.java
@@ -52,4 +52,6 @@ public interface LRS {
     LRSResponse saveAgentProfile(AgentProfileDocument profile);
     LRSResponse updateAgentProfile(AgentProfileDocument profile);
     LRSResponse deleteAgentProfile(AgentProfileDocument profile);
+	
+	void destroy();
 }

--- a/src/main/java/com/rusticisoftware/tincan/RemoteLRS.java
+++ b/src/main/java/com/rusticisoftware/tincan/RemoteLRS.java
@@ -810,4 +810,16 @@ public class RemoteLRS implements LRS {
 
         return deleteDocument("agents/profile", queryParams);
     }
+	
+	@Override
+	public void destroy() {
+		if (this._httpClient != null) {
+			try {
+				this._httpClient.stop();
+				this._httpClient.destroy();
+			} catch (Exception ex) {
+				throw new RuntimeException(ex);
+			}
+		}
+	}
 }


### PR DESCRIPTION
Threads remain active within Java EE applications, without decent shutdown