### PR TITLE
Modify parameterized constructor, Statement(StringOfJSON), of Statement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ target/test-classes/
 .classpath
 .project
 .settings/
+/target/

--- a/src/main/java/com/rusticisoftware/tincan/Statement.java
+++ b/src/main/java/com/rusticisoftware/tincan/Statement.java
@@ -18,12 +18,7 @@ package com.rusticisoftware.tincan;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
-import java.util.List;
 import java.util.UUID;
-
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
@@ -33,6 +28,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.rusticisoftware.tincan.internal.StatementBase;
 import com.rusticisoftware.tincan.json.StringOfJSON;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 /**
  * Statement Class
@@ -45,7 +44,7 @@ public class Statement extends StatementBase {
     private DateTime stored;
     private Agent authority;
     private TCAPIVersion version;
-    
+
     @Deprecated
     private Boolean voided;
 
@@ -66,12 +65,12 @@ public class Statement extends StatementBase {
         if (! authorityNode.isMissingNode()) {
             this.setAuthority(Agent.fromJson(authorityNode));
         }
-        
+
         JsonNode voidedNode = jsonNode.path("voided");
         if (! voidedNode.isMissingNode()) {
             this.setVoided(voidedNode.asBoolean());
         }
-        
+
         JsonNode versionNode = jsonNode.path("version");
         if (! versionNode.isMissingNode()) {
             this.setVersion(TCAPIVersion.fromString(versionNode.textValue()));
@@ -79,7 +78,7 @@ public class Statement extends StatementBase {
     }
 
     public Statement(StringOfJSON jsonStr) throws IOException, URISyntaxException {
-        super(jsonStr);
+        this(jsonStr.toJSONNode());
     }
 
     public Statement(Agent actor, Verb verb, StatementTarget object, Result result, Context context) {
@@ -104,21 +103,21 @@ public class Statement extends StatementBase {
         if (this.authority != null) {
             node.put("authority", this.getAuthority().toJSONNode(version));
         }
-        
+
         //Include 0.95 specific fields if asking for 0.95 version
         if (TCAPIVersion.V095.equals(version)) {
             if (this.getVoided() != null) {
                 node.put("voided", this.getVoided());
             }
         }
-        
+
         //Include 1.0.x specific fields if asking for 1.0.x version
         if (version.ordinal() <= TCAPIVersion.V100.ordinal()) {
             if (this.getVersion() != null) {
                 node.put("version", this.getVersion().toString());
             }
         }
-        
+
         return node;
     }
 

--- a/src/main/java/com/rusticisoftware/tincan/Statement.java
+++ b/src/main/java/com/rusticisoftware/tincan/Statement.java
@@ -18,7 +18,12 @@ package com.rusticisoftware.tincan;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.UUID;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
 
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
@@ -28,10 +33,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.rusticisoftware.tincan.internal.StatementBase;
 import com.rusticisoftware.tincan.json.StringOfJSON;
-
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 
 /**
  * Statement Class
@@ -44,7 +45,7 @@ public class Statement extends StatementBase {
     private DateTime stored;
     private Agent authority;
     private TCAPIVersion version;
-
+    
     @Deprecated
     private Boolean voided;
 
@@ -65,12 +66,12 @@ public class Statement extends StatementBase {
         if (! authorityNode.isMissingNode()) {
             this.setAuthority(Agent.fromJson(authorityNode));
         }
-
+        
         JsonNode voidedNode = jsonNode.path("voided");
         if (! voidedNode.isMissingNode()) {
             this.setVoided(voidedNode.asBoolean());
         }
-
+        
         JsonNode versionNode = jsonNode.path("version");
         if (! versionNode.isMissingNode()) {
             this.setVersion(TCAPIVersion.fromString(versionNode.textValue()));

--- a/src/test/java/com/rusticisoftware/tincan/StatementTest.java
+++ b/src/test/java/com/rusticisoftware/tincan/StatementTest.java
@@ -15,9 +15,8 @@
 */
 package com.rusticisoftware.tincan;
 
-import static com.rusticisoftware.tincan.TestUtils.*;
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.*;
+import static com.rusticisoftware.tincan.TestUtils.assertSerializeDeserialize;
+import static com.rusticisoftware.tincan.TestUtils.getAgent;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +27,8 @@ import org.junit.Test;
 
 import com.rusticisoftware.tincan.json.StringOfJSON;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 /**
  * Description
  */

--- a/src/test/java/com/rusticisoftware/tincan/StatementTest.java
+++ b/src/test/java/com/rusticisoftware/tincan/StatementTest.java
@@ -15,8 +15,9 @@
 */
 package com.rusticisoftware.tincan;
 
-import static com.rusticisoftware.tincan.TestUtils.assertSerializeDeserialize;
-import static com.rusticisoftware.tincan.TestUtils.getAgent;
+import static com.rusticisoftware.tincan.TestUtils.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +26,8 @@ import java.util.UUID;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
+import com.rusticisoftware.tincan.json.StringOfJSON;
+
 /**
  * Description
  */
@@ -32,19 +35,19 @@ public class StatementTest {
 
     @Test
     public void serializeDeserialize() throws Exception {
-        
+
         List<StatementTarget> statementTargets = new ArrayList<StatementTarget>();
         statementTargets.add(new Activity("http://example.com/activity"));
         statementTargets.add(getAgent("Target", "mbox", "mailto:target@example.com"));
         statementTargets.add(new StatementRef(UUID.randomUUID()));
-        
+
         SubStatement sub = new SubStatement();
         sub.setActor(getAgent("Sub", "mbox", "mailto:sub@example.com"));
         sub.setVerb(new Verb("http://example.com/verb"));
         sub.setObject(new Activity("http://example.com/sub-activity"));
         statementTargets.add(sub);
-        
-        
+
+
         Statement st = new Statement();
         st.setActor(getAgent("Joe", "mbox", "mailto:joe@example.com"));
 
@@ -52,24 +55,76 @@ public class StatementTest {
         Attachment att = new Attachment();
         att.setSha2("abc");
         st.getAttachments().add(att);
-        
+
         st.setAuthority(getAgent("Authority", "mbox", "mailto:authority@example.com"));
-        
+
         st.setContext(new Context());
         st.getContext().setLanguage("en-US");
-        
+
         st.setId(UUID.randomUUID());
-        
+
         st.setResult(new Result());
         st.getResult().setCompletion(true);
-        
+
         st.setStored(new DateTime());
         st.setTimestamp(new DateTime());
         st.setVerb(new Verb("http://example.com/verb"));
-        
+
         for (StatementTarget target : statementTargets) {
             st.setObject(target);
             assertSerializeDeserialize(st);
+        }
+    }
+
+
+    /**
+     * To assert that {@Link Statement(StringOfJSON)} converts all textbased-elements in StringOfJSON to {@Link Statement}
+     *
+     * @throws Exception
+     */
+    @Test
+    public void StatementConstructorTest() throws Exception {
+
+        List<StatementTarget> statementTargets = new ArrayList<StatementTarget>();
+        statementTargets.add(new Activity("http://example.com/activity"));
+        statementTargets.add(getAgent("Target", "mbox", "mailto:target@example.com"));
+        statementTargets.add(new StatementRef(UUID.randomUUID()));
+
+        SubStatement sub = new SubStatement();
+        sub.setActor(getAgent("Sub", "mbox", "mailto:sub@example.com"));
+        sub.setVerb(new Verb("http://example.com/verb"));
+        sub.setObject(new Activity("http://example.com/sub-activity"));
+        statementTargets.add(sub);
+
+        Statement st = new Statement();
+        st.setActor(getAgent("Joe", "mbox", "mailto:joe@example.com"));
+
+        st.setAttachments(new ArrayList<Attachment>());
+        Attachment att = new Attachment();
+        att.setSha2("abc");
+        st.getAttachments().add(att);
+
+        st.setAuthority(getAgent("Authority", "mbox", "mailto:authority@example.com"));
+
+        st.setContext(new Context());
+        st.getContext().setLanguage("en-US");
+
+        st.setId(UUID.randomUUID());
+
+        st.setResult(new Result());
+        st.getResult().setCompletion(true);
+
+        st.setStored(new DateTime());
+        st.setTimestamp(new DateTime());
+        st.setVerb(new Verb("http://example.com/verb"));
+
+
+        for (StatementTarget target : statementTargets) {
+            st.setObject(target);
+
+            Statement tmpStatement = new Statement(new StringOfJSON(st.toJSON()));
+
+            assertThat(st.toJSON(), is(tmpStatement.toJSON()));
         }
     }
 }


### PR DESCRIPTION
Some variables, ID,Stored,Authority,Voided and Version, are missed when Statement instance is made by parameterized constructor, Statement(StringOfJSON). 

I put new test code into com.rusticisoftware.tincan.StatementTest.

Please consider to modify the constructor Statement(StringOfJSON).

--added 
Seems like this issue already showed up issue #39.